### PR TITLE
Update key configuration to use XKB keysyms instead of Linux keycodes

### DIFF
--- a/docs/configuration/custom_actions.md
+++ b/docs/configuration/custom_actions.md
@@ -13,7 +13,7 @@ custom_actions:           # Set meta + D to open wofi
     action: down
     modifiers:
       - primary
-    key: KEY_D
+    key: d
 ```
 
 ## Schema
@@ -25,7 +25,7 @@ custom_actions:
   - command: <string>
     action: <up|down|repeat|modifiers>
     modifiers: <Modifier[]>
-    key: <KeyCodeName>
+    key: <KeysymName>
 ```
 
 ## Properties
@@ -76,9 +76,11 @@ custom_actions:
 
 ### `key`
 
-:   <small>required</small> **type:** KeyCodeName
+:   <small>required</small> **type:** KeysymName
 
-    Name of the keycode that the action responds to. See the [Linux input event codes](https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h) for available keycodes (e.g., `KEY_ENTER`, `KEY_Z`, etc.)
+    Name of the XKB keysym that the action responds to. See the [xkbcommon keysym list](https://xkbcommon.org/doc/current/xbkcommon-keysyms_8h.html) for available names (e.g., `Return`, `z`, `Up`).
+
+    For shifted characters, use the shifted keysym directly instead of combining a lowercase key with the `shift` modifier. For example, use `Q` instead of `q` + `shift`, and use `exclam` instead of `1` + `shift`.
 
 ## Default
 ```yaml

--- a/docs/configuration/default_keybinds.md
+++ b/docs/configuration/default_keybinds.md
@@ -50,7 +50,7 @@ default_action_overrides:
     modifiers:
       - ctrl
       - shift
-    key: KEY_ENTER
+    key: Return
 ```
 
 ## Schema
@@ -62,7 +62,7 @@ default_action_overrides:
   - name: <string>
     action: <up|down|repeat|modifiers>
     modifiers: <Modifier[]>
-    key: <KeyCodeName>
+    key: <KeysymName>
 ```
 
 ## Properties
@@ -113,9 +113,11 @@ default_action_overrides:
 
 ### `key`
 
-:   <small>required</small> **type:** KeyCodeName
+:   <small>required</small> **type:** KeysymName
 
-    Name of the keycode that the action responds to. See the [Linux input event codes](https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h) for available keycodes (e.g., `KEY_ENTER`, `KEY_Z`, etc.)
+    Name of the XKB keysym that the action responds to. See the [xkbcommon keysym list](https://xkbcommon.org/doc/current/xbkcommon-keysyms_8h.html) for available names (e.g., `Return`, `z`, `Up`).
+
+    For shifted characters, use the shifted keysym directly instead of combining a lowercase key with the `shift` modifier. For example, use `Q` instead of `q` + `shift`, and use `exclam` instead of `1` + `shift`.
 
 ## Default
 ```yaml


### PR DESCRIPTION
## Summary
This PR updates the documentation for key configuration in custom actions and default keybinds to use XKB keysyms instead of Linux input event keycodes. This reflects a change in the underlying key specification format.

## Key Changes
- Updated `key` field type from `KeyCodeName` to `KeysymName` in both custom_actions and default_keybinds documentation
- Changed example key values from Linux keycode format (e.g., `KEY_D`, `KEY_ENTER`) to XKB keysym format (e.g., `d`, `Return`)
- Updated documentation references from Linux input event codes to the xkbcommon keysym list
- Added guidance for shifted characters, recommending the use of shifted keysyms directly (e.g., `Q`, `exclam`) instead of combining lowercase keys with the `shift` modifier

## Notable Details
- The change applies consistently across both configuration files (custom_actions.md and default_keybinds.md)
- Documentation now points to the xkbcommon keysym reference instead of the Linux kernel input event codes header
- Added explicit examples showing the preferred approach for shifted characters to prevent user confusion

https://claude.ai/code/session_01TmzWY43We4CSgERzeQq3xs